### PR TITLE
Update image-request.ts

### DIFF
--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -453,6 +453,7 @@ export class ImageRequest {
       case "FFD8FFED":
       case "FFD8FFEE":
       case "FFD8FFE1":
+      case "FFD8FFE2":
         return ContentTypes.JPEG;
       case "52494646":
         return ContentTypes.WEBP;

--- a/source/image-handler/test/image-request/infer-image-type.spec.ts
+++ b/source/image-handler/test/image-request/infer-image-type.spec.ts
@@ -13,34 +13,15 @@ describe("inferImageType", () => {
   const secretProvider = new SecretProvider(secretsManager);
 
   test.each([
-    { value: [0xff, 0xd8, 0xff, 0xee, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], label: "FFD8FFEE" },
-    { value: [0xff, 0xd8, 0xff, 0xe2, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], label: "FFD8FFE2" },
-  ])('Should pass if it returns "image/jpeg" for a magic number of $label', ({ value, label }) => {
-    const imageBuffer = Buffer.from(value);
-
-    // Act
-    const imageRequest = new ImageRequest(s3Client, secretProvider);
-    const result = imageRequest.inferImageType(imageBuffer);
-
-    // Assert
-    expect(result).toEqual("image/jpeg");
-  });
-
-  it('Should pass if it returns "image/jpeg"', () => {
-    // Arrange
-    const imageBuffer = Buffer.from([0xff, 0xd8, 0xff, 0xee, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
-
-    // Act
-    const imageRequest = new ImageRequest(s3Client, secretProvider);
-    const result = imageRequest.inferImageType(imageBuffer);
-
-    // Assert
-    expect(result).toEqual("image/jpeg");
-  });
-
-  it('Should pass if it returns "image/jpeg for a magic number of FFD8FFED"', () => {
-    // Arrange
-    const imageBuffer = Buffer.from([0xff, 0xd8, 0xff, 0xed, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    { value: "FFD8FFDB" },
+    { value: "FFD8FFE0" },
+    { value: "FFD8FFED" },
+    { value: "FFD8FFEE" },
+    { value: "FFD8FFE1" },
+    { value: "FFD8FFE2" },
+  ])('Should pass if it returns "image/jpeg" for a magic number of $value', ({ value }) => {
+    const byteValues = value.match(/.{1,2}/g).map((x) => parseInt(x, 16));
+    const imageBuffer = Buffer.from(byteValues.concat(new Array(8).fill(0x00)));
 
     // Act
     const imageRequest = new ImageRequest(s3Client, secretProvider);

--- a/source/image-handler/test/image-request/infer-image-type.spec.ts
+++ b/source/image-handler/test/image-request/infer-image-type.spec.ts
@@ -12,6 +12,20 @@ describe("inferImageType", () => {
   const secretsManager = new SecretsManager();
   const secretProvider = new SecretProvider(secretsManager);
 
+  test.each([
+    { value: [0xff, 0xd8, 0xff, 0xee, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], label: "FFD8FFEE" },
+    { value: [0xff, 0xd8, 0xff, 0xe2, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], label: "FFD8FFE2" },
+  ])('Should pass if it returns "image/jpeg" for a magic number of $label', ({ value, label }) => {
+    const imageBuffer = Buffer.from(value);
+
+    // Act
+    const imageRequest = new ImageRequest(s3Client, secretProvider);
+    const result = imageRequest.inferImageType(imageBuffer);
+
+    // Assert
+    expect(result).toEqual("image/jpeg");
+  });
+
   it('Should pass if it returns "image/jpeg"', () => {
     // Arrange
     const imageBuffer = Buffer.from([0xff, 0xd8, 0xff, 0xee, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);


### PR DESCRIPTION
Extend JPG magic numbers to include FFD8FFE2, and extend tests to cover other magic number cases.

**Issue #, if available:**
Addresses: https://github.com/aws-solutions/serverless-image-handler/issues/484

**Description of changes:**
Extend valid magic numbers for JPG format to include FFD8FFE2.

**Checklist**
- [x] :wave: I have added unit tests for all code changes.
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
